### PR TITLE
Added the $ORIGIN directive

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,6 +43,7 @@ DEFAULT_2NDLABELS = [
     '_domainkey',
     ]
 ZONE_TPL = """; {domainname}
+$ORIGIN {domainname}
 $TTL 3600               ; Default TTL in secs(1 hour)
 @       SOA ns1.d9t.de. domainmaster.d9t.de. (
         {serial}      ; Serial number yyyymmddvv


### PR DESCRIPTION
The $ORIGIN directive is expected by some BIND file parsers.

From http://www.zytrax.com/books/dns/ch8/origin.html :

> $ORIGIN defines a base name from which 'unqualified' names (those without a terminating dot) substitutions are made when processing the zone file. Zone files which do not contain an $ORIGIN directive, while being perfectly legitimate, can also be highly confusing. In general, always explicitly define an $ORIGIN directive unless there is a very good reason not to (sloth is not a very good reason).